### PR TITLE
Dependabot Patch Auto Merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ie3-institute/python-project'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Check Pre-Release
+        run: |
+          NEW="${{ steps.metadata.outputs.new-version }}"
+          if [[ "$NEW" =~ ([0-9]+!)?[0-9]+(\.[0-9]+)*((a|b|rc)[0-9]*|\.dev[0-9]*) ]]; then
+            echo "::error::Pre-release version ($NEW) detected – workflow stopped."
+            exit 1
+          fi
+
+      - name: Approve the PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Close #84 
This pull request adds a new GitHub Actions workflow to automate the approval and merging of patch-level Dependabot pull requests, while ensuring that pre-release versions are not merged. The workflow is triggered only for Dependabot PRs in the `ie3-institute/python-project` repository.

Automation of Dependabot PRs:

* Added `.github/workflows/dependabot-auto-merge.yml` to automatically approve and enable auto-merge for Dependabot PRs that perform patch-level semantic version updates, using the GitHub CLI and metadata from the Dependabot action.

Pre-release safeguards:

* Implemented a check to detect and stop the workflow if the new version in the PR is a pre-release (e.g., alpha, beta, release candidate, or dev versions), preventing accidental merging of unstable dependencies.